### PR TITLE
Fix `profile` endpoint crashing randomly

### DIFF
--- a/src/models/profile.rs
+++ b/src/models/profile.rs
@@ -40,8 +40,10 @@ pub struct ProfileSet {
     pub store: HashMap<String, ProfileConfig>,
 
     #[serde(rename = "mills")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mills: Option<i64>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub units: Option<String>,
 
     #[napi(js_name = "createdAt")]
@@ -52,7 +54,9 @@ pub struct ProfileSet {
 #[napi(object)]
 pub struct ProfileConfig {
     pub dia: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub carbs_hr: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<f64>,
     pub timezone: String,
     pub units: String,


### PR DESCRIPTION
This fixes an issue `ProfileSet` and `ProfileConfig` where some values weren't set as `Option<T>`. This caused crashes because those values can be null.